### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
 ### MYQL-CLI
 
 [![Build Status](https://travis-ci.org/josuebrunel/myql-cli.svg)](https://travis-ci.org/josuebrunel/myql-cli) [![Documentation Status](https://readthedocs.org/projects/myql-cli/badge/?version=latest)](https://myql-cli.readthedocs.org/)
-[![Latest Version](https://img.shields.io/pypi/v/myql-cli.svg
-[![Downloads](https://img.shields.io/pypi/dm/myql-cli.svg 
-[![Python Version](https://img.shields.io/pypi/pyversions/myql-cli.svg
-[![Python Implementation](https://img.shields.io/pypi/implementation/myql-cli.svg
+[![Latest Version](https://img.shields.io/pypi/v/myql-cli.svg)](https://pypi.python.org/pypi/myql/)
+[![Python Version](https://img.shields.io/pypi/pyversions/myql-cli.svg)](https://pypi.python.org/pypi/myql/)
+[![Python Implementation](https://img.shields.io/pypi/implementation/myql-cli.svg)](https://pypi.python.org/pypi/myql/)
 
 ***MYQL-cli*** is a command line tool to run YQL queries or to generate YQL OpenTable.
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 ### MYQL-CLI
 
 [![Build Status](https://travis-ci.org/josuebrunel/myql-cli.svg)](https://travis-ci.org/josuebrunel/myql-cli) [![Documentation Status](https://readthedocs.org/projects/myql-cli/badge/?version=latest)](https://myql-cli.readthedocs.org/)
-[![Latest Version](https://pypip.in/version/myql-cli/badge.svg)](https://pypi.python.org/pypi/myql/)
-[![Downloads](https://pypip.in/download/myql-cli/badge.svg)](https://pypi.python.org/pypi/myql) 
-[![Python Version](https://pypip.in/py_versions/myql-cli/badge.svg)](https://pypi.python.org/pypi/myql)
-[![Python Implementation](https://pypip.in/implementation/myql-cli/badge.svg)](https://pypi.python.org/pypi/myql)
+[![Latest Version](https://img.shields.io/pypi/v/myql-cli.svg
+[![Downloads](https://img.shields.io/pypi/dm/myql-cli.svg 
+[![Python Version](https://img.shields.io/pypi/pyversions/myql-cli.svg
+[![Python Implementation](https://img.shields.io/pypi/implementation/myql-cli.svg
 
 ***MYQL-cli*** is a command line tool to run YQL queries or to generate YQL OpenTable.
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20myql-cli))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `myql-cli`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.